### PR TITLE
feat: implement VASEY/AI universal branded footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Reddit+Sans:wght@300;400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Reddit+Sans:wght@300;400;500;600&family=Space+Mono&display=swap"
       rel="stylesheet"
     />
     <link
@@ -191,11 +191,70 @@
 
       </main>
 
-      <footer class="footer">
-        <p>
-          Powered by publicly available orbital data (Celestrak) and open-source tooling. Always verify viewing
-          conditions locally.
-        </p>
+      <!-- App Footer — VASEY/AI Brand Identity -->
+      <footer class="app-footer">
+        <div class="footer-divider"></div>
+        <div class="footer-brand-row">
+
+          <!-- Vasey Multimedia — VM Monogram -->
+          <a href="https://vaseymultimedia.com" target="_blank" rel="noopener" class="footer-logo" aria-label="Vasey Multimedia">
+            <svg class="footer-logo-vm" viewBox="0 0 688 592" xmlns="http://www.w3.org/2000/svg">
+              <g transform="translate(0,592) scale(0.1,-0.1)" fill="currentColor" color="var(--text-secondary)">
+                <path d="M20 3827 l0 -2073 251 -265 c138 -145 281 -299 317 -341 37 -42 70
+-76 74 -75 3 1 8 851 10 1889 2 1038 8 1891 12 1895 5 4 11 2 13 -5 3 -7 51
+-70 106 -139 144 -178 444 -556 611 -767 77 -98 193 -245 257 -325 64 -80 223
+-281 353 -446 130 -165 301 -381 380 -480 78 -99 205 -261 282 -359 76 -99
+176 -227 222 -285 46 -58 104 -133 130 -166 323 -418 405 -517 415 -499 13 24
+111 152 237 309 83 104 193 244 345 438 22 29 76 97 120 153 44 56 116 148
+160 205 44 57 213 270 375 474 162 203 307 386 322 405 15 19 89 112 165 207
+76 94 174 218 217 275 44 57 202 258 350 447 317 403 353 448 409 521 l42 55
+3 -1903 c1 -1047 6 -1902 10 -1900 4 2 50 50 102 108 52 58 184 197 294 310
+110 113 211 221 225 241 l26 35 0 225 c0 123 -1 1053 -2 2067 l-3 1842 -323 0
+c-309 0 -323 -1 -332 -19 -6 -11 -57 -79 -115 -151 -126 -158 -178 -226 -377
+-486 -83 -109 -191 -249 -240 -311 -48 -61 -166 -212 -262 -335 -197 -251
+-337 -430 -522 -663 -70 -88 -146 -186 -170 -217 -120 -155 -371 -476 -528
+-673 -96 -121 -198 -249 -226 -285 -28 -36 -111 -140 -184 -232 l-133 -166
+-27 31 c-15 18 -49 61 -77 97 -27 36 -103 133 -169 216 -66 82 -164 206 -217
+275 -53 68 -170 216 -258 329 -89 113 -276 354 -417 535 -141 182 -289 371
+-328 420 -39 50 -128 162 -196 250 -69 88 -181 232 -250 319 -68 87 -221 283
+-339 435 -119 152 -271 345 -338 429 -67 84 -129 164 -138 177 l-16 25 -324 0
+-324 0 0 -2073z M1209 5883 c5 -10 66 -90 136 -178 69 -88 176 -225 238 -305
+61 -80 146 -188 187 -241 41 -52 106 -136 145 -185 38 -49 121 -155 185 -235
+63 -80 141 -179 172 -220 62 -79 308 -394 532 -679 213 -272 298 -381 471
+-603 88 -114 162 -206 165 -206 3 0 21 21 41 47 19 26 109 141 200 256 90 115
+247 315 348 445 236 302 465 594 547 696 102 128 375 474 563 716 96 123 216
+276 266 339 50 63 136 171 190 240 l98 125 -374 3 c-292 2 -375 0 -380 -10 -4
+-7 -102 -132 -218 -278 -116 -146 -223 -281 -238 -301 -98 -128 -269 -345
+-333 -423 -41 -50 -93 -116 -115 -146 -22 -30 -78 -102 -125 -160 -78 -96
+-186 -232 -388 -490 -41 -52 -79 -95 -83 -95 -5 0 -46 48 -91 106 -101 129
+-455 578 -750 949 -509 643 -621 786 -642 817 l-21 33 -368 0 c-347 0 -367 -1
+-358 -17z M1130 2171 l0 -1484 163 -166 c156 -159 343 -353 437 -453 25 -27
+48 -48 53 -48 4 0 7 637 7 1415 l0 1415 -33 37 c-19 21 -151 184 -295 363
+-144 179 -277 343 -296 365 l-35 40 -1 -1484z M5633 3532 c-50 -64 -193 -245
+-317 -401 l-226 -284 0 -1413 c0 -887 4 -1414 10 -1414 5 0 13 6 17 14 10 18
+110 125 267 286 66 69 175 181 241 250 l120 125 -3 1478 c-1 812 -5 1477 -10
+1476 -4 0 -48 -53 -99 -117z"/>
+              </g>
+            </svg>
+          </a>
+
+          <div class="footer-logo-sep"></div>
+
+          <!-- VASEY/AI — VA Monogram -->
+          <a href="https://vasey.ai" target="_blank" rel="noopener" class="footer-logo" aria-label="VASEY/AI">
+            <svg class="footer-logo-va" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 20.0,63.2 L 189.0,356.4 L 235.1,282.3 L 380.0,281.7 L 242.4,43.6 L 169.4,167.1 L 195.8,211.0 L 242.4,133.4 L 301.9,235.7 L 265.4,236.2 L 237.9,189.6 L 191.3,267.7 L 98.1,108.7 L 166.0,108.2 L 192.4,63.2 Z" fill="currentColor" color="var(--text-secondary)" stroke="none"/>
+            </svg>
+          </a>
+
+        </div>
+
+        <div class="footer-suite-tag">A VASEY/AI Production</div>
+        <div class="footer-app-tag">ISS Observer v1.2.0 · Real-Time ISS Tracker</div>
+        <div class="footer-copyright">
+          © 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br>
+          Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>
+        </div>
       </footer>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iss-observer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iss-observer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@joergdietrich/leaflet.terminator": "^1.0.0",
         "@vercel/analytics": "^1.6.1",

--- a/src/style.css
+++ b/src/style.css
@@ -21,6 +21,15 @@
   --radius: 16px;
   --radius-sm: 10px;
   font-family: 'Reddit Sans', system-ui, -apple-system, sans-serif;
+
+  /* VASEY/AI Footer — custom property aliases */
+  --border-subtle: var(--border);
+  --border-glow: var(--turquoise-glow);
+  --accent-deep: var(--turquoise-dark);
+  --accent-dim: #1a9e8f;
+  --accent-primary: var(--turquoise);
+  --text-muted: var(--muted);
+  --accent-glow-strong: rgba(45, 212, 191, 0.5);
 }
 
 /* Keyframe Animations */
@@ -762,13 +771,104 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
-/* === FOOTER === */
-.footer {
+/* === VASEY/AI Universal Footer === */
+.app-footer {
+  margin-top: 56px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-subtle);
   text-align: center;
-  color: var(--muted);
-  font-size: 0.82rem;
-  padding: 0 5vw 2rem;
   padding-bottom: calc(2rem + env(safe-area-inset-bottom));
+  animation: fadeInUp 0.8s ease-out 0.8s both;
+}
+
+.footer-divider {
+  width: 48px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent-deep), transparent);
+  margin: 0 auto 28px;
+  animation: footerDividerPulse 3s ease-in-out infinite;
+}
+
+@keyframes footerDividerPulse {
+  0%, 100% { opacity: 0.6; width: 48px; }
+  50%      { opacity: 1;   width: 72px; }
+}
+
+.footer-brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.footer-logo {
+  opacity: 0.45;
+  transition: opacity 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+}
+.footer-logo:hover {
+  opacity: 0.85;
+  filter: drop-shadow(0 0 6px var(--accent-glow-strong));
+}
+
+.footer-logo-vm {
+  width: 36px;
+  height: 31px;
+}
+
+.footer-logo-va {
+  width: 34px;
+  height: 34px;
+}
+
+.footer-logo-sep {
+  width: 1px;
+  height: 24px;
+  background: var(--border-glow);
+}
+
+.footer-suite-tag {
+  font-family: 'Reddit Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.footer-app-tag {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.7;
+  margin-bottom: 16px;
+}
+
+.footer-copyright {
+  font-family: 'Reddit Sans', sans-serif;
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.5;
+  line-height: 1.6;
+  padding-bottom: 8px;
+}
+
+.footer-copyright a {
+  color: var(--accent-dim);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-copyright a:hover {
+  color: var(--accent-primary);
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* === ISS ICON & MARKER === */


### PR DESCRIPTION
Replace the minimal text footer with the VASEY/AI branded footer template,
customized for ISS Observer's monochrome + turquoise design system.

Changes:
- Add CSS custom property aliases (--border-subtle, --accent-deep, etc.)
  mapping to existing ISS Observer palette variables
- Replace .footer with full .app-footer component: VM/VA vector logos,
  production credit, app version tag, and copyright block
- Add Space Mono font for the app tag monospace styling
- Enable Enhancement A (glow pulse divider) for space-age feel
- Enable Enhancement C (turquoise logo hover glow) matching accent color
- Add fadeInUp keyframe animation for footer entry

Verified: npm run lint ✓ | npm test (3/3 pass) ✓ | vite build ✓

https://claude.ai/code/session_01HfEjksRSNZvmDmrWaMus6h