### PR TITLE
fix: align PWA status-bar colors with light theme and add dvh app-shell height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] — 2026-06-12
+
+### Fixed
+- Corrected `theme-color` meta and manifest `theme_color` from `#111827` (the ink/text token) to `#ffffff` (`--bg-pure`, the hero background) so the status-bar region renders as a seamless continuation of the app background in installed PWA mode and Safari tab tinting, instead of a dark band over the light UI.
+- Changed `apple-mobile-web-app-status-bar-style` from `black-translucent` to `default` — the app is light-themed, so the white status-bar text rendered by `black-translucent` was invisible against the white hero in iOS standalone mode.
+- Added `min-height: 100dvh` on `body` (with `100vh` fallback) so the app shell fills the dynamic viewport on mobile browsers.
+
+### Changed
+- Bumped version to 1.3.2 across package.json, index.html, service worker cache name, and README so installed PWAs pick up the corrected head metadata.
+
 ## [1.3.1] — 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://developer.mozilla.org/docs/Web/JavaScript"><img src="https://img.shields.io/badge/JavaScript-ES2022-F7DF1E?logo=javascript&logoColor=000000" alt="JavaScript"></a>
   <a href="https://vite.dev"><img src="https://img.shields.io/badge/Vite-7.x-646CFF?logo=vite&logoColor=ffffff" alt="Vite"></a>
   <a href="#pwa"><img src="https://img.shields.io/badge/PWA-Installable-5A0FC8?logo=pwa&logoColor=ffffff" alt="PWA"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Version-1.3.1-111827" alt="Version"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Version-1.3.2-111827" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-3DA639" alt="License"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node-%3E%3D18-339933?logo=node.js&logoColor=ffffff" alt="Node"></a>
   <a href="https://celestrak.org"><img src="https://img.shields.io/badge/Orbital%20Data-Celestrak-0066CC" alt="Orbital Data"></a>
@@ -108,7 +108,7 @@ Setting a contact email is recommended for production to comply with the [OpenSt
 ```
 .
 ├── index.html              # App shell with PWA meta tags
-├── package.json            # Dependencies and scripts (v1.3.1)
+├── package.json            # Dependencies and scripts (v1.3.2)
 ├── vite.config.js          # Vite build configuration
 ├── vercel.json             # Vercel deployment and headers
 ├── .env.example            # Environment variable template

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
       name="description"
       content="Real-time ISS tracking, pass predictions, and viewing recommendations for any location."
     />
-    <meta name="theme-color" content="#111827" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="ISS Observer" />
     <link rel="icon" type="image/svg+xml" href="./public/favicon.svg" />
     <link rel="apple-touch-icon" href="./public/iss-icon.svg" />
@@ -44,7 +44,7 @@
               <img src="./public/iss-icon.svg" alt="ISS icon" width="44" height="44" />
             </span>
             <h1>ISS Observer</h1>
-            <span class="version-pill">v1.3.1</span>
+            <span class="version-pill">v1.3.2</span>
           </div>
           <p class="hero__subhead">
             Real-time International Space Station tracking with personalized pass predictions and visibility analysis.
@@ -252,7 +252,7 @@ c-309 0 -323 -1 -332 -19 -6 -11 -57 -79 -115 -151 -126 -158 -178 -226 -377
         </div>
 
         <div class="footer-suite-tag">A VASEY/AI Production</div>
-        <div class="footer-app-tag">ISS Observer v1.3.1 · Real-Time ISS Tracker</div>
+        <div class="footer-app-tag">ISS Observer v1.3.2 · Real-Time ISS Tracker</div>
         <div class="footer-copyright">
           © 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br>
           Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iss-observer",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "Real-time ISS tracking PWA with pass predictions, visibility analysis, and synchronized 2D/3D visualization",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#f0f2f5",
-  "theme_color": "#111827",
+  "theme_color": "#ffffff",
   "orientation": "portrait-primary",
   "categories": ["education", "utilities"],
   "icons": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'iss-observer-v1.3.1';
+const CACHE_NAME = 'iss-observer-v1.3.2';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/style.css
+++ b/src/style.css
@@ -89,6 +89,7 @@ body {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+  min-height: 100dvh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
The theme-color meta and manifest theme_color were set to #111827 — the
design system's ink/text token, not a background — which painted a dark
status-bar band over the white hero in installed PWA mode and Safari tab
tinting. Both now use #ffffff (--bg-pure, the hero's actual background).

apple-mobile-web-app-status-bar-style was black-translucent, which renders
white status-bar text invisibly against the white hero in iOS standalone
mode; changed to default for dark text. The hero already extends its
background under the status bar via env(safe-area-inset-top), so no CSS
changes were needed for background coverage.

Added min-height: 100dvh on body (100vh fallback) so the app shell tracks
the dynamic mobile viewport.

Bumped to 1.3.2 across package.json, index.html, sw.js cache name, README,
and CHANGELOG so installed PWAs invalidate the precached index.html and
manifest.

Verified: npm run lint, npm test (0 failures), npm run build — built
dist/index.html and dist/manifest.json confirmed to carry the corrected
values.

https://claude.ai/code/session_016EP7uTgErbkU4nnkud788N