### PR TITLE
fix: mask top safe area so content scrolls under the iOS status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Added a fixed top safe-area scrim (`body::before`, `height: env(safe-area-inset-top)`) filled with `--bg-pure` so scrolling content passes beneath the iOS status bar / Dynamic Island instead of colliding with the system clock and icons. The fill matches the hero surface and `theme-color`, so the region is indistinguishable from the app background at rest; the layer is `pointer-events: none`, adds no layout shift, and collapses to zero height on devices without a top inset.
+
 ## [1.3.2] — 2026-06-12
 
 ### Fixed

--- a/src/style.css
+++ b/src/style.css
@@ -94,6 +94,27 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Top safe-area scrim — opaque mask over the iOS status bar / Dynamic Island
+   region so scrolling content passes beneath the system clock and icons.
+   Filled with --bg-pure to exactly match the hero surface that owns the top
+   edge at rest (and the #ffffff theme-color / manifest theme_color), so the
+   scrim is invisible when scrolled to top. The hero's own
+   env(safe-area-inset-top) padding keeps its content clear of this region —
+   the inset is applied once, there. Height collapses to 0 where no top inset
+   exists (desktop, landscape). */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: env(safe-area-inset-top, 0px);
+  background: var(--bg-pure);
+  /* Above Leaflet panes/controls (z-index ≤ 1000) so map content also masks */
+  z-index: 1200;
+  pointer-events: none;
+}
+
 #app {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Add a single fixed scrim (body::before) spanning env(safe-area-inset-top),
filled with --bg-pure to exactly match the hero surface that owns the top
edge and the #ffffff theme-color, so the region is invisible at rest and
opaquely masks content mid-scroll. pointer-events: none, z-index above
Leaflet panes, zero layout shift; height collapses to 0 without a top
inset. The hero keeps its existing inset padding as the single application
of the top inset — no double-counting.

Verified: npm run lint, npm test (all passing), npm run build all green.

https://claude.ai/code/session_013uKSXPyKmgjikNQgRQfVK3