### PR TITLE
feat: fix share links, add top pick actions, move settings to sticky top bar (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] — 2026-07-10
 
 ### Fixed
-- Moved horizontal safe-area insets from the `#app` container into each section's own padding (`.hero`, `main`, `.app-footer`) so the hero's full-width white surface bleeds edge-to-edge in landscape on notched devices instead of exposing gray body-background strips beside it. Insets remain applied once per edge per element.
-- Completed the iOS safe-area blend for the light theme: added the `mobile-web-app-capable` meta (standards-track companion to the Apple-prefixed one), aligned manifest `background_color` with the `#ffffff` top-of-page color so the launch background flows seamlessly into the status-bar region and hero, and added an `html` reset with `-webkit-text-size-adjust: 100%` and dynamic-viewport min-height.
+- **Share links now work.** Opening a shared pass URL (`?lat&lon&pass`) previously did nothing useful: the `pass` parameter was never read, and on any device that had used the app before, the locally saved location silently overwrote the shared coordinates. Share links now take precedence over the saved location, match the shared pass against fresh orbital data (±15 min tolerance for TLE drift), pin it into the visible list regardless of pagination, highlight it with a "Shared pick" badge, scroll it into view, and explain the outcome in a dismissible banner — including friendly messaging when the shared pass has already occurred. Manually changing location exits shared mode and cleans the URL so a refresh returns to normal behavior.
+- Share links now carry the location name (`loc` param, capped at 80 chars, placeholder names omitted) so recipients see a real place name immediately; links without one are reverse-geocoded in the background.
+- Top picks always appear in the Upcoming Passes list (prioritization already guaranteed this; the shared pass is now also pinned when it would otherwise fall outside the 25-pass display cap).
+- Top picks and pass lists no longer show passes that have already ended when re-rendered long after computation.
+
+### Added
+- **Top pick actions** — each Top Pick card now has a rank badge ("Pick 1/2/3") and two actions: "View pass" jumps to the full pass card in Upcoming Passes (navigating pagination and flashing the card), and "Share" opens the native share sheet or copies the link.
+- `src/lib/share.js` — extracted, pure share-link helpers (`buildShareParams`, `parseShareParams`, `findSharedPass`) with full unit-test coverage in `tests/share.test.js` (regression tests for the broken-share-link bug).
+- Toast notifications (`role="status"`, `aria-live="polite"`) for copy/share/reminder feedback — previously copy feedback appeared as text inside the distant Location panel.
+- Calendar reminder downloads now confirm via toast.
 
 ### Changed
-- Centralized safe-area insets as `:root` tokens (`--safe-top/right/bottom/left`, wrapping `env(safe-area-inset-*)` with `0px` fallbacks) and migrated all six inset usages (top scrim, hero, app container, footer, standalone/mobile overrides) to them. No visual change — single source of truth for notch/home-indicator clearance.
-- Added a fixed top safe-area scrim (`body::before`, `height: env(safe-area-inset-top)`) filled with `--bg-pure` so scrolling content passes beneath the iOS status bar / Dynamic Island instead of colliding with the system clock and icons. The fill matches the hero surface and `theme-color`, so the region is indistinguishable from the app background at rest; the layer is `pointer-events: none`, adds no layout shift, and collapses to zero height on devices without a top inset.
+- **Settings moved into a new sticky top bar.** The full-width collapsible SETTINGS panel wedged between Location and Top Picks (awkward on mobile) is gone. A slim, always-visible top bar now carries the VASEY/SPACE brand and a Settings button that opens an anchored popover (same four controls, same persistence) — reachable from anywhere on the page, closable via Escape, outside tap, or the button. The hero eyebrow moved into the bar; disclosure semantics (`aria-expanded`/`aria-controls`) retained.
+- The top bar replaces the fixed `body::before` safe-area scrim: as the topmost sticky element it owns the top safe-area inset (applied once) and masks content scrolling beneath the iOS status bar with a blurred translucent surface. The standalone-mode hero padding override is no longer needed and was removed.
+- Share/Reminder and card action buttons render compact and side-by-side on phones instead of stacked full-width.
+- Bumped version to 1.4.0 across package.json, index.html (pill + footer), service worker cache name, and README.
+
+### Fixed (carried from unreleased)
+- Moved horizontal safe-area insets from the `#app` container into each section's own padding (`.hero`, `main`, `.app-footer`) so the hero's full-width white surface bleeds edge-to-edge in landscape on notched devices instead of exposing gray body-background strips beside it. Insets remain applied once per edge per element.
+- Completed the iOS safe-area blend for the light theme: added the `mobile-web-app-capable` meta (standards-track companion to the Apple-prefixed one), aligned manifest `background_color` with the `#ffffff` top-of-page color so the launch background flows seamlessly into the status-bar region and hero, and added an `html` reset with `-webkit-text-size-adjust: 100%` and dynamic-viewport min-height.
+- Centralized safe-area insets as `:root` tokens (`--safe-top/right/bottom/left`, wrapping `env(safe-area-inset-*)` with `0px` fallbacks) as the single source of truth for notch/home-indicator clearance.
 
 ## [1.3.2] — 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://developer.mozilla.org/docs/Web/JavaScript"><img src="https://img.shields.io/badge/JavaScript-ES2022-F7DF1E?logo=javascript&logoColor=000000" alt="JavaScript"></a>
   <a href="https://vite.dev"><img src="https://img.shields.io/badge/Vite-7.x-646CFF?logo=vite&logoColor=ffffff" alt="Vite"></a>
   <a href="#pwa"><img src="https://img.shields.io/badge/PWA-Installable-5A0FC8?logo=pwa&logoColor=ffffff" alt="PWA"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Version-1.3.2-111827" alt="Version"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Version-1.4.0-111827" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-3DA639" alt="License"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node-%3E%3D18-339933?logo=node.js&logoColor=ffffff" alt="Node"></a>
   <a href="https://celestrak.org"><img src="https://img.shields.io/badge/Orbital%20Data-Celestrak-0066CC" alt="Orbital Data"></a>
@@ -28,7 +28,8 @@ A real-time International Space Station tracker that combines orbital telemetry,
 - **Top pick recommendations** — best viewing opportunities scored by elevation (50%), duration (30%), and sky darkness (20%).
 - **Countdown timer** — live countdown to the next upcoming pass.
 - **Dual visualization** — synchronized 2D Leaflet ground track map and 3D Globe.gl interactive globe with day/night terminator overlay and a 3D ISS model rendered on the globe.
-- **Reminders + sharing** — downloadable `.ics` calendar invites and shareable URLs with encoded pass details.
+- **Reminders + sharing** — downloadable `.ics` calendar invites and shareable deep links that open with the shared location applied and the shared pass pinned, highlighted, and scrolled into view.
+- **Sticky top bar with settings** — brand bar pinned to the top of the page with a settings popover (units, update rate, time format, default view) reachable from anywhere in the app.
 - **Installable PWA** — service worker with offline caching, web app manifest, and iOS home screen support.
 - **Mobile-first design** — optimized for iOS with safe area insets, touch-friendly controls, and responsive breakpoints.
 - **Monochrome aesthetic** — clean light backgrounds with dark text providing stark contrast for a space-age look.
@@ -108,7 +109,7 @@ Setting a contact email is recommended for production to comply with the [OpenSt
 ```
 .
 ├── index.html              # App shell with PWA meta tags
-├── package.json            # Dependencies and scripts (v1.3.2)
+├── package.json            # Dependencies and scripts (v1.4.0)
 ├── vite.config.js          # Vite build configuration
 ├── vercel.json             # Vercel deployment and headers
 ├── .env.example            # Environment variable template
@@ -119,7 +120,8 @@ Setting a contact email is recommended for production to comply with the [OpenSt
 │   └── lib/
 │       ├── format.js       # Formatting helpers, scoring, brightness
 │       ├── orbit.js        # TLE fetch/cache, propagation, sun position
-│       └── passes.js       # 72-hour pass prediction, visibility
+│       ├── passes.js       # 72-hour pass prediction, visibility
+│       └── share.js        # Share link build/parse + shared pass matching
 ├── public/
 │   ├── config.js           # Runtime configuration
 │   ├── manifest.json       # PWA web app manifest
@@ -127,7 +129,8 @@ Setting a contact email is recommended for production to comply with the [OpenSt
 │   ├── favicon.svg         # Browser tab icon (square-cropped ISS)
 │   └── iss-icon.svg        # ISS illustration icon
 ├── tests/
-│   └── format.test.js      # Unit tests for format helpers
+│   ├── format.test.js      # Unit tests for format helpers
+│   └── share.test.js       # Unit tests for share link helpers
 ├── scripts/
 │   ├── lint.mjs            # Syntax linter
 │   ├── build.mjs           # Legacy build script

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -8,6 +8,7 @@
 - `src/lib/format.js` — Formatting helpers, scoring, and brightness estimation.
 - `src/lib/orbit.js` — TLE fetch/cache, orbital propagation, sun position, and sunlight detection.
 - `src/lib/passes.js` — 72-hour pass prediction and visibility analysis.
+- `src/lib/share.js` — Share link build/parse helpers and shared-pass matching.
 
 ## Public Assets
 
@@ -20,6 +21,7 @@
 ## Testing
 
 - `tests/format.test.js` — Unit tests for format helpers (Node.js native test runner).
+- `tests/share.test.js` — Unit tests for share link helpers and shared-pass matching.
 
 ## Infrastructure
 

--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
     <!-- Sticky top bar lives outside #app: its overflow-x clipping would
          disable position: sticky for any descendant. -->
     <header class="topbar">
-        <div class="topbar__inner">
-          <p class="topbar__brand">VASEY/<span class="topbar__brand-category">SPACE</span></p>
+      <div class="topbar__inner">
+        <p class="topbar__brand">VASEY/<span class="topbar__brand-category">SPACE</span></p>
           <button
             id="settings-toggle"
             class="topbar__settings"
@@ -53,40 +53,40 @@
             </svg>
             <span class="topbar__settings-label">Settings</span>
           </button>
-        </div>
-        <div id="settings-menu" class="settings-menu" hidden>
-          <h2 id="settings-heading" class="section-title">SETTINGS</h2>
-          <div class="settings__grid">
-            <label class="field">
-              <span>Units</span>
-              <select id="setting-units">
-                <option value="imperial" selected>Imperial (mi, mph)</option>
-                <option value="metric">Metric (km, km/s)</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Update rate</span>
-              <select id="setting-rate">
-                <option value="1000">1 sec</option>
-                <option value="5000">5 sec</option>
-                <option value="10000">10 sec</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Time format</span>
-              <select id="setting-time">
-                <option value="24">24 hour</option>
-                <option value="12">12 hour</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>Default view</span>
-              <select id="setting-view">
-                <option value="both">2D + 3D</option>
-                <option value="map">2D map only</option>
-                <option value="globe">3D globe only</option>
-              </select>
-            </label>
+          <div id="settings-menu" class="settings-menu" hidden>
+            <h2 id="settings-heading" class="section-title">SETTINGS</h2>
+            <div class="settings__grid">
+              <label class="field">
+                <span>Units</span>
+                <select id="setting-units">
+                  <option value="imperial" selected>Imperial (mi, mph)</option>
+                  <option value="metric">Metric (km, km/s)</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Update rate</span>
+                <select id="setting-rate">
+                  <option value="1000">1 sec</option>
+                  <option value="5000">5 sec</option>
+                  <option value="10000">10 sec</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Time format</span>
+                <select id="setting-time">
+                  <option value="24">24 hour</option>
+                  <option value="12">12 hour</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Default view</span>
+                <select id="setting-view">
+                  <option value="both">2D + 3D</option>
+                  <option value="map">2D map only</option>
+                  <option value="globe">3D globe only</option>
+                </select>
+              </label>
+            </div>
           </div>
         </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -35,17 +35,72 @@
     <script defer src="/_vercel/insights/script.js"></script>
   </head>
   <body>
+    <!-- Sticky top bar lives outside #app: its overflow-x clipping would
+         disable position: sticky for any descendant. -->
+    <header class="topbar">
+        <div class="topbar__inner">
+          <p class="topbar__brand">VASEY/<span class="topbar__brand-category">SPACE</span></p>
+          <button
+            id="settings-toggle"
+            class="topbar__settings"
+            type="button"
+            aria-expanded="false"
+            aria-controls="settings-menu"
+          >
+            <svg class="topbar__settings-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="3.2" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            <span class="topbar__settings-label">Settings</span>
+          </button>
+        </div>
+        <div id="settings-menu" class="settings-menu" hidden>
+          <h2 id="settings-heading" class="section-title">SETTINGS</h2>
+          <div class="settings__grid">
+            <label class="field">
+              <span>Units</span>
+              <select id="setting-units">
+                <option value="imperial" selected>Imperial (mi, mph)</option>
+                <option value="metric">Metric (km, km/s)</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Update rate</span>
+              <select id="setting-rate">
+                <option value="1000">1 sec</option>
+                <option value="5000">5 sec</option>
+                <option value="10000">10 sec</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Time format</span>
+              <select id="setting-time">
+                <option value="24">24 hour</option>
+                <option value="12">12 hour</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Default view</span>
+              <select id="setting-view">
+                <option value="both">2D + 3D</option>
+                <option value="map">2D map only</option>
+                <option value="globe">3D globe only</option>
+              </select>
+            </label>
+          </div>
+        </div>
+    </header>
+
     <div id="app">
-      <header class="hero">
+      <section class="hero" aria-label="ISS Observer overview">
         <div class="hero__content">
-          <p class="hero__eyebrow">VASEY/<span class="hero__eyebrow-category">SPACE</span></p>
           <div class="hero__brand">
             <div class="hero__brand-glow" aria-hidden="true"></div>
             <span class="iss-icon hero__icon">
               <img src="./public/iss-icon.svg" alt="ISS icon" width="44" height="44" />
             </span>
             <h1>ISS Observer</h1>
-            <span class="version-pill">v1.3.2</span>
+            <span class="version-pill">v1.4.0</span>
           </div>
           <p class="hero__subhead">
             Real-time International Space Station tracking with personalized pass predictions and visibility analysis.
@@ -69,7 +124,7 @@
             </div>
           </div>
         </div>
-      </header>
+      </section>
 
       <main>
         <section class="panel location-panel" aria-labelledby="location-heading">
@@ -102,49 +157,6 @@
               <button id="apply-location" class="button" type="button">Update predictions</button>
             </div>
             <p id="location-feedback" class="helper-text" role="status" aria-live="polite"></p>
-          </div>
-        </section>
-
-        <section class="panel settings-dropdown" aria-labelledby="settings-heading">
-          <button class="settings-dropdown__toggle" id="settings-toggle" type="button" aria-expanded="false" aria-controls="settings-content">
-            <h2 id="settings-heading" class="section-title">SETTINGS</h2>
-            <svg class="settings-dropdown__chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
-          <div class="settings-dropdown__content" id="settings-content" hidden>
-            <div class="settings__grid">
-              <label class="field">
-                <span>Units</span>
-                <select id="setting-units">
-                  <option value="imperial" selected>Imperial (mi, mph)</option>
-                  <option value="metric">Metric (km, km/s)</option>
-                </select>
-              </label>
-              <label class="field">
-                <span>Update rate</span>
-                <select id="setting-rate">
-                  <option value="1000">1 sec</option>
-                  <option value="5000">5 sec</option>
-                  <option value="10000">10 sec</option>
-                </select>
-              </label>
-              <label class="field">
-                <span>Time format</span>
-                <select id="setting-time">
-                  <option value="24">24 hour</option>
-                  <option value="12">12 hour</option>
-                </select>
-              </label>
-              <label class="field">
-                <span>Default view</span>
-                <select id="setting-view">
-                  <option value="both">2D + 3D</option>
-                  <option value="map">2D map only</option>
-                  <option value="globe">3D globe only</option>
-                </select>
-              </label>
-            </div>
           </div>
         </section>
 
@@ -186,6 +198,14 @@
             <p class="section-description">
               Detailed rise, peak, and set times for your location. Visible passes require dark skies and a sunlit ISS.
             </p>
+          </div>
+          <div id="share-banner" class="share-banner" hidden>
+            <svg class="share-banner__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+            </svg>
+            <p id="share-banner-text" class="share-banner__text" role="status" aria-live="polite"></p>
+            <button id="share-banner-dismiss" class="share-banner__dismiss" type="button" aria-label="Dismiss shared pass notice">&times;</button>
           </div>
           <div id="passes" class="passes"></div>
         </section>
@@ -253,12 +273,14 @@ c-309 0 -323 -1 -332 -19 -6 -11 -57 -79 -115 -151 -126 -158 -178 -226 -377
         </div>
 
         <div class="footer-suite-tag">A VASEY/AI Production</div>
-        <div class="footer-app-tag">ISS Observer v1.3.2 · Real-Time ISS Tracker</div>
+        <div class="footer-app-tag">ISS Observer v1.4.0 · Real-Time ISS Tracker</div>
         <div class="footer-copyright">
           © 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br>
           Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>
         </div>
       </footer>
+
+      <div id="toast" class="toast" role="status" aria-live="polite"></div>
     </div>
 
     <script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iss-observer",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "description": "Real-time ISS tracking PWA with pass predictions, visibility analysis, and synchronized 2D/3D visualization",
   "scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'iss-observer-v1.3.2';
+const CACHE_NAME = 'iss-observer-v1.4.0';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/lib/share.js
+++ b/src/lib/share.js
@@ -1,0 +1,103 @@
+// Shareable pass link helpers.
+// A share link encodes the observer location and the pass start time so a
+// recipient sees the same pick: ?lat=<deg>&lon=<deg>&pass=<ISO>&loc=<name>
+
+// Successive ISS passes are ~90 minutes apart, so a generous ±15 minute
+// tolerance absorbs TLE drift between sharer and recipient without ever
+// matching a neighboring pass.
+export const PASS_MATCH_TOLERANCE_MS = 15 * 60 * 1000;
+
+const MAX_LOCATION_NAME_LENGTH = 80;
+
+// Placeholder names that carry no meaning for a recipient; omitted from
+// links so the recipient's device resolves a real name instead.
+const PLACEHOLDER_NAMES = new Set([
+  'custom location',
+  'custom coordinates',
+  'shared location',
+  'locating...'
+]);
+
+export const isPlaceholderName = (name) =>
+  PLACEHOLDER_NAMES.has(String(name || '').trim().toLowerCase());
+
+/**
+ * Build the query params for a share link.
+ * @param {{lat: number, lon: number}} observer
+ * @param {{start: Date}} pass
+ * @param {string} [locationName]
+ * @returns {URLSearchParams}
+ */
+export const buildShareParams = (observer, pass, locationName = '') => {
+  const params = new URLSearchParams();
+  params.set('lat', observer.lat.toFixed(4));
+  params.set('lon', observer.lon.toFixed(4));
+  params.set('pass', pass.start.toISOString());
+  const name = String(locationName).trim();
+  if (name && !isPlaceholderName(name)) {
+    params.set('loc', name.slice(0, MAX_LOCATION_NAME_LENGTH));
+  }
+  return params;
+};
+
+/**
+ * Parse share params from a query string. Invalid or out-of-range values
+ * are dropped rather than throwing, so a mangled link degrades gracefully.
+ * @param {string} search - window.location.search (with or without '?')
+ * @returns {{observer: {lat: number, lon: number}|null, passTime: Date|null, locationName: string}}
+ */
+export const parseShareParams = (search) => {
+  const params = new URLSearchParams(search);
+  const result = { observer: null, passTime: null, locationName: '' };
+
+  const lat = Number.parseFloat(params.get('lat'));
+  const lon = Number.parseFloat(params.get('lon'));
+  if (
+    Number.isFinite(lat) && lat >= -90 && lat <= 90 &&
+    Number.isFinite(lon) && lon >= -180 && lon <= 180
+  ) {
+    result.observer = { lat, lon };
+  }
+
+  const passParam = params.get('pass');
+  if (passParam) {
+    const time = new Date(passParam);
+    if (!Number.isNaN(time.getTime())) {
+      result.passTime = time;
+    }
+  }
+
+  const loc = String(params.get('loc') || '').trim();
+  if (loc && !isPlaceholderName(loc)) {
+    result.locationName = loc.slice(0, MAX_LOCATION_NAME_LENGTH);
+  }
+
+  return result;
+};
+
+/**
+ * Find the pass a shared timestamp refers to. Matches when the target falls
+ * within the pass window (± tolerance) and prefers the pass whose start time
+ * is closest to the target.
+ * @param {Array<{start: Date, end: Date}>} passes
+ * @param {Date|null} targetTime
+ * @param {number} [toleranceMs]
+ * @returns {object|null}
+ */
+export const findSharedPass = (passes, targetTime, toleranceMs = PASS_MATCH_TOLERANCE_MS) => {
+  if (!targetTime || Number.isNaN(targetTime.getTime())) return null;
+  const target = targetTime.getTime();
+  let best = null;
+  let bestDelta = Infinity;
+  for (const pass of passes) {
+    const windowStart = pass.start.getTime() - toleranceMs;
+    const windowEnd = pass.end.getTime() + toleranceMs;
+    if (target < windowStart || target > windowEnd) continue;
+    const delta = Math.abs(pass.start.getTime() - target);
+    if (delta < bestDelta) {
+      best = pass;
+      bestDelta = delta;
+    }
+  }
+  return best;
+};

--- a/src/main.js
+++ b/src/main.js
@@ -30,12 +30,21 @@ import {
   getSunSubPoint
 } from './lib/orbit.js';
 import { computePasses, describeVisibility } from './lib/passes.js';
+import { buildShareParams, parseShareParams, findSharedPass } from './lib/share.js';
 
 const state = {
   satrec: null,
   observer: { lat: 47.6062, lon: -122.3321, height: 0 },
   locationName: 'Seattle, WA',
   passes: [],
+  // Context carried by an opened share link (?lat&lon&pass). While active,
+  // the shared location wins over the locally saved one and the matched
+  // pass is pinned + highlighted in the list.
+  share: {
+    active: false,
+    passTime: null,
+    matched: null
+  },
   settings: {
     units: 'imperial',
     updateRate: 1000,
@@ -65,7 +74,11 @@ const elements = {
   settingUnits: document.querySelector('#setting-units'),
   settingRate: document.querySelector('#setting-rate'),
   settingTime: document.querySelector('#setting-time'),
-  settingView: document.querySelector('#setting-view')
+  settingView: document.querySelector('#setting-view'),
+  shareBanner: document.querySelector('#share-banner'),
+  shareBannerText: document.querySelector('#share-banner-text'),
+  shareBannerDismiss: document.querySelector('#share-banner-dismiss'),
+  toast: document.querySelector('#toast')
 };
 
 let map;
@@ -420,10 +433,34 @@ const updateVisibilityNow = () => {
   }
 };
 
+let toastTimer;
+const showToast = (message) => {
+  if (!elements.toast) return;
+  elements.toast.textContent = message;
+  elements.toast.classList.add('toast--visible');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    elements.toast.classList.remove('toast--visible');
+  }, 3200);
+};
+
+const showShareBanner = (message) => {
+  if (!elements.shareBanner || !elements.shareBannerText) return;
+  elements.shareBannerText.textContent = message;
+  elements.shareBanner.hidden = false;
+};
+
+const hideShareBanner = () => {
+  if (elements.shareBanner) {
+    elements.shareBanner.hidden = true;
+  }
+};
+
 const renderTopPicks = () => {
   elements.topPicks.innerHTML = '';
+  const now = new Date();
   const picks = [...state.passes]
-    .filter((pass) => pass.visible)
+    .filter((pass) => pass.visible && pass.end > now)
     .sort((a, b) => b.score - a.score)
     .slice(0, 3);
 
@@ -433,11 +470,14 @@ const renderTopPicks = () => {
     return;
   }
 
-  picks.forEach((pass) => {
-    const card = document.createElement('div');
-    card.className = 'card';
+  picks.forEach((pass, index) => {
+    const card = document.createElement('article');
+    card.className = 'card card--pick';
     card.innerHTML = `
-      <div class="badge badge--score">Score ${pass.score}</div>
+      <div class="card__badges">
+        <span class="badge badge--rank">Pick ${index + 1}</span>
+        <span class="badge badge--score">Score ${pass.score}</span>
+      </div>
       <p class="card__title">${formatDateTime(
         pass.start,
         state.settings.timeFormat
@@ -445,17 +485,51 @@ const renderTopPicks = () => {
       <p class="card__meta">Peak ${pass.maxElevation.toFixed(
         0
       )}° | ${formatDuration(pass.duration)} | ${pass.brightness}</p>
+      <div class="card__actions">
+        <button class="button button--small" type="button" data-view>View pass</button>
+        <button class="button button--small" type="button" data-share>Share</button>
+      </div>
     `;
+    card.querySelector('[data-view]').addEventListener('click', () => {
+      if (!jumpToPass(pass)) {
+        showToast('This pass is no longer in the upcoming list.');
+      }
+    });
+    card.querySelector('[data-share]').addEventListener('click', () => {
+      sharePass(pass);
+    });
     elements.topPicks.appendChild(card);
   });
 };
 
 const buildShareUrl = (pass) => {
-  const params = new URLSearchParams();
-  params.set('lat', state.observer.lat.toFixed(4));
-  params.set('lon', state.observer.lon.toFixed(4));
-  params.set('pass', pass.start.toISOString());
+  const params = buildShareParams(state.observer, pass, state.locationName);
   return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+};
+
+const sharePass = async (pass) => {
+  const shareUrl = buildShareUrl(pass);
+  if (navigator.share) {
+    try {
+      await navigator.share({
+        title: 'ISS pass details',
+        text: `ISS pass over ${state.locationName} — ${formatDateTime(pass.start, state.settings.timeFormat)}`,
+        url: shareUrl
+      });
+      return;
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        return; // User dismissed the share sheet
+      }
+      // Share sheet unavailable — fall back to the clipboard below
+    }
+  }
+  try {
+    await navigator.clipboard.writeText(shareUrl);
+    showToast('Share link copied to clipboard.');
+  } catch {
+    showToast('Unable to copy the share link.');
+  }
 };
 
 const createICS = (pass) => {
@@ -492,6 +566,13 @@ const getDisplayPasses = () => {
     .slice(0, 3);
 
   const prioritized = [...firstVisible, ...bonusVisible];
+
+  // Pin the pass a share link points at so it is always in the list
+  const shared = state.share.matched;
+  if (shared && upcoming.includes(shared) && !prioritized.includes(shared)) {
+    prioritized.push(shared);
+  }
+
   const prioritizedSet = new Set(prioritized);
 
   // Fill remaining slots with chronological passes (visible or not)
@@ -503,16 +584,51 @@ const getDisplayPasses = () => {
   return [...prioritized, ...rest].sort((a, b) => a.start - b.start).slice(0, MAX_DISPLAY_PASSES);
 };
 
+/**
+ * Navigate the passes list to the page containing a pass, then scroll to
+ * and briefly highlight its card. Returns false if the pass is not listed.
+ */
+const jumpToPass = (pass) => {
+  const displayPasses = getDisplayPasses();
+  const index = displayPasses.indexOf(pass);
+  if (index === -1) return false;
+
+  const targetPage = Math.floor(index / PASSES_PER_PAGE);
+  if (targetPage !== passPage) {
+    passPage = targetPage;
+    renderPasses();
+  }
+
+  requestAnimationFrame(() => {
+    const target = elements.passes.querySelector(
+      `[data-pass-start="${pass.start.toISOString()}"]`
+    );
+    if (!target) return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    target.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+    // Restart the flash animation if it was already applied
+    target.classList.remove('pass--flash');
+    void target.offsetWidth;
+    target.classList.add('pass--flash');
+  });
+  return true;
+};
+
 const renderPassCard = (pass) => {
   const container = document.createElement('div');
-  container.className = `pass${pass.visible ? ' pass--visible' : ''}`;
+  const isShared = state.share.matched === pass;
+  container.className = `pass${pass.visible ? ' pass--visible' : ''}${isShared ? ' pass--shared' : ''}`;
+  container.dataset.passStart = pass.start.toISOString();
   const directionLabel = `${formatAzimuth(pass.startAz)} → ${formatAzimuth(
     pass.endAz
   )}`;
   container.innerHTML = `
     <div class="pass__header">
       <div>
-        <div class="badge${pass.visible ? ' badge--visible' : ''}">${pass.visible ? 'Visible' : 'Overhead'}</div>
+        <div class="pass__badges">
+          <div class="badge${pass.visible ? ' badge--visible' : ''}">${pass.visible ? 'Visible' : 'Overhead'}</div>
+          ${isShared ? '<div class="badge badge--shared">Shared pick</div>' : ''}
+        </div>
         <p class="card__title">${formatDateTime(
           pass.start,
           state.settings.timeFormat
@@ -561,28 +677,8 @@ const renderPassCard = (pass) => {
   const shareButton = container.querySelector('[data-share]');
   const remindButton = container.querySelector('[data-remind]');
 
-  shareButton.addEventListener('click', async () => {
-    const shareUrl = buildShareUrl(pass);
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: 'ISS pass details',
-          text: `Next ISS pass over ${state.locationName}`,
-          url: shareUrl
-        });
-      } catch {
-        // User cancelled share dialog
-      }
-    } else {
-      try {
-        await navigator.clipboard.writeText(shareUrl);
-        elements.locationFeedback.textContent =
-          'Share link copied to clipboard.';
-      } catch {
-        elements.locationFeedback.textContent =
-          'Unable to copy link.';
-      }
-    }
+  shareButton.addEventListener('click', () => {
+    sharePass(pass);
   });
 
   remindButton.addEventListener('click', () => {
@@ -594,6 +690,7 @@ const renderPassCard = (pass) => {
     link.download = `iss-pass-${pass.start.toISOString().slice(0, 10)}.ics`;
     link.click();
     URL.revokeObjectURL(url);
+    showToast('Calendar reminder downloaded.');
   });
 
   return container;
@@ -768,11 +865,54 @@ const recalcPasses = () => {
   if (!state.satrec) return;
   state.passes = computePasses(state.satrec, state.observer);
   passPage = 0;
+  if (state.share.active && state.share.passTime) {
+    state.share.matched = findSharedPass(state.passes, state.share.passTime);
+  }
   updateNextPass();
   renderTopPicks();
   renderPasses();
   updateVisibilityNow();
   updateCountdown();
+};
+
+/**
+ * Surface the pass a share link points at: jump to it and explain the
+ * outcome in the banner (matched, already occurred, or unmatchable).
+ */
+const focusSharedPass = () => {
+  if (!state.share.active) return;
+  const { timeFormat } = state.settings;
+
+  if (!state.share.passTime) {
+    showShareBanner('Shared location loaded — showing its latest pass predictions below.');
+    return;
+  }
+
+  const match = state.share.matched;
+  const now = new Date();
+  if (match && match.end > now) {
+    showShareBanner(`Shared pass loaded: ${formatDateTime(match.start, timeFormat)} — highlighted below.`);
+    jumpToPass(match);
+    return;
+  }
+
+  const sharedLabel = formatDateTime(state.share.passTime, timeFormat);
+  if (state.share.passTime <= now) {
+    showShareBanner(`The shared pass (${sharedLabel}) has already occurred. Showing the next opportunities for this location.`);
+  } else {
+    showShareBanner(`The shared pass (${sharedLabel}) no longer matches current orbital data. Showing the latest predictions for this location.`);
+  }
+};
+
+/**
+ * Leave shared-link mode: called when the user picks their own location so
+ * the saved location and a page refresh behave normally again.
+ */
+const clearShareContext = () => {
+  if (!state.share.active) return;
+  state.share = { active: false, passTime: null, matched: null };
+  hideShareBanner();
+  window.history.replaceState(null, '', window.location.pathname);
 };
 
 const applyLocation = async (lat, lon, name = '') => {
@@ -781,6 +921,8 @@ const applyLocation = async (lat, lon, name = '') => {
     elements.locationFeedback.textContent = 'Coordinates out of valid range.';
     return;
   }
+
+  clearShareContext();
 
   state.observer.lat = lat;
   state.observer.lon = lon;
@@ -880,38 +1022,37 @@ const updateLocationDisplay = () => {
 };
 
 const bindEvents = () => {
-  // Settings dropdown toggle
+  // Settings popover in the top bar (disclosure pattern)
   const settingsToggle = document.querySelector('#settings-toggle');
-  const settingsPanel = document.querySelector('.settings-dropdown');
-  const settingsContent = document.querySelector('#settings-content');
-  if (settingsToggle) {
-    const setSettingsExpanded = (expanded) => {
-      settingsToggle.setAttribute('aria-expanded', String(expanded));
-      if (settingsPanel) settingsPanel.classList.toggle('is-open', expanded);
-      if (!settingsContent) return;
-
-      if (expanded) {
-        settingsContent.hidden = false;
-        requestAnimationFrame(() => {
-          if (settingsPanel) settingsPanel.classList.add('is-open');
-        });
-      } else {
-        if (settingsContent.hidden) return;
-        const handleClose = () => {
-          settingsContent.hidden = true;
-          settingsContent.removeEventListener('transitionend', handleClose);
-        };
-        settingsContent.addEventListener('transitionend', handleClose);
-      }
+  const settingsMenu = document.querySelector('#settings-menu');
+  if (settingsToggle && settingsMenu) {
+    const setSettingsOpen = (open) => {
+      settingsToggle.setAttribute('aria-expanded', String(open));
+      settingsMenu.hidden = !open;
     };
 
-    const isExpanded = settingsToggle.getAttribute('aria-expanded') === 'true';
-    setSettingsExpanded(isExpanded);
-
     settingsToggle.addEventListener('click', () => {
-      const expanded = settingsToggle.getAttribute('aria-expanded') === 'true';
-      setSettingsExpanded(!expanded);
+      setSettingsOpen(settingsMenu.hidden);
     });
+
+    // Close when tapping/clicking outside the menu
+    document.addEventListener('pointerdown', (event) => {
+      if (settingsMenu.hidden) return;
+      if (settingsMenu.contains(event.target) || settingsToggle.contains(event.target)) return;
+      setSettingsOpen(false);
+    });
+
+    // Close on Escape and hand focus back to the toggle
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !settingsMenu.hidden) {
+        setSettingsOpen(false);
+        settingsToggle.focus();
+      }
+    });
+  }
+
+  if (elements.shareBannerDismiss) {
+    elements.shareBannerDismiss.addEventListener('click', hideShareBanner);
   }
 
   window.addEventListener('resize', () => {
@@ -1099,18 +1240,19 @@ const startLoop = () => {
   loopId = setInterval(updateLoop, state.settings.updateRate);
 };
 
+/**
+ * Apply share-link params. Returns true when a valid shared location was
+ * found — in that case the link wins over the locally saved location.
+ */
 const hydrateFromUrl = () => {
-  const params = new URLSearchParams(window.location.search);
-  const lat = params.get('lat');
-  const lon = params.get('lon');
-  if (lat && lon) {
-    const parsedLat = parseFloat(lat);
-    const parsedLon = parseFloat(lon);
-    if (!Number.isNaN(parsedLat) && !Number.isNaN(parsedLon)) {
-      state.observer.lat = parsedLat;
-      state.observer.lon = parsedLon;
-    }
-  }
+  const { observer, passTime, locationName } = parseShareParams(window.location.search);
+  if (!observer) return false;
+  state.observer.lat = observer.lat;
+  state.observer.lon = observer.lon;
+  state.locationName = locationName || 'Shared location';
+  state.share.active = true;
+  state.share.passTime = passTime;
+  return true;
 };
 
 // Register service worker for PWA
@@ -1128,7 +1270,7 @@ const init = async () => {
   try {
     elements.issStatus.textContent = 'Initializing...';
     loadSettings();
-    hydrateFromUrl();
+    const fromShareLink = hydrateFromUrl();
     initVisualization();
     applySettings();
     updateLocationInputs();
@@ -1138,20 +1280,35 @@ const init = async () => {
       resizeGlobe();
     });
 
-    // Load saved location
-    try {
-      const savedLocation = localStorage.getItem('vasey-location');
-      if (savedLocation) {
-        const parsed = JSON.parse(savedLocation);
-        state.observer.lat = parsed.lat;
-        state.observer.lon = parsed.lon;
-        state.locationName = parsed.name || 'Custom location';
-        map.setView([state.observer.lat, state.observer.lon], 3);
-        userMarker.setLatLng([state.observer.lat, state.observer.lon]);
-        updateLocationInputs();
+    if (!fromShareLink) {
+      // Load saved location — skipped for share links so the link's
+      // location is never overridden by a previously saved one
+      try {
+        const savedLocation = localStorage.getItem('vasey-location');
+        if (savedLocation) {
+          const parsed = JSON.parse(savedLocation);
+          state.observer.lat = parsed.lat;
+          state.observer.lon = parsed.lon;
+          state.locationName = parsed.name || 'Custom location';
+          map.setView([state.observer.lat, state.observer.lon], 3);
+          userMarker.setLatLng([state.observer.lat, state.observer.lon]);
+          updateLocationInputs();
+        }
+      } catch {
+        // localStorage unavailable or corrupt
       }
-    } catch {
-      // localStorage unavailable or corrupt
+    } else if (state.locationName === 'Shared location') {
+      // Link carried no place name — resolve one in the background
+      reverseGeocode(state.observer.lat, state.observer.lon)
+        .then((name) => {
+          if (name && state.share.active) {
+            state.locationName = name;
+            updateLocationDisplay();
+          }
+        })
+        .catch(() => {
+          // Keep the placeholder name
+        });
     }
     updateLocationDisplay();
 
@@ -1162,6 +1319,7 @@ const init = async () => {
         const tle = await fetchTle();
         state.satrec = getSatrec(tle);
         recalcPasses();
+        focusSharedPass();
         startLoop();
         updateLoop();
         break;

--- a/src/style.css
+++ b/src/style.css
@@ -111,25 +111,114 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Top safe-area scrim — opaque mask over the iOS status bar / Dynamic Island
-   region so scrolling content passes beneath the system clock and icons.
-   Filled with --bg-pure to exactly match the hero surface that owns the top
-   edge at rest (and the #ffffff theme-color / manifest theme_color), so the
-   scrim is invisible when scrolled to top. The hero's own
-   var(--safe-top) padding keeps its content clear of this region —
-   the inset is applied once, there. Height collapses to 0 where no top inset
-   exists (desktop, landscape). */
-body::before {
-  content: '';
-  position: fixed;
+/* === TOP BAR === */
+/* Sticky bar owning the top screen edge: it carries the top safe-area inset
+   (applied once, here — see tasks/lessons.md) and masks content scrolling
+   beneath the iOS status bar. Lives outside #app because #app's
+   overflow-x: hidden would disable position: sticky. */
+.topbar {
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
-  height: var(--safe-top);
+  /* Above Leaflet panes/controls (z-index ≤ 1000) so map content passes under */
+  z-index: 1100;
+  background: rgba(255, 255, 255, 0.92);
+  -webkit-backdrop-filter: blur(14px) saturate(1.4);
+  backdrop-filter: blur(14px) saturate(1.4);
+  border-bottom: 1px solid var(--border);
+  padding-top: var(--safe-top);
+  padding-left: calc(5vw + var(--safe-left));
+  padding-right: calc(5vw + var(--safe-right));
+}
+
+.topbar__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 52px;
+}
+
+.topbar__brand {
+  font-family: 'Bebas Neue', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: #9aa7d6;
+  margin: 0;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.topbar__brand-category {
+  color: var(--turquoise-dark);
+}
+
+.topbar__settings {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--border-strong);
   background: var(--bg-pure);
-  /* Above Leaflet panes/controls (z-index ≤ 1000) so map content also masks */
-  z-index: 1200;
-  pointer-events: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.4rem 0.95rem;
+  border-radius: 999px;
+  cursor: pointer;
+  min-height: 40px;
+  transition: all 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.topbar__settings:hover {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--bg-pure);
+}
+
+.topbar__settings:focus-visible {
+  outline: 2px solid var(--turquoise-dark);
+  outline-offset: 2px;
+}
+
+.topbar__settings-icon {
+  flex-shrink: 0;
+  transition: transform 0.25s ease;
+}
+
+.topbar__settings[aria-expanded="true"] .topbar__settings-icon {
+  transform: rotate(45deg);
+}
+
+/* Settings popover anchored under the bar */
+.settings-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: calc(5vw + var(--safe-right));
+  width: min(460px, calc(100vw - 10vw - var(--safe-left) - var(--safe-right)));
+  background: var(--panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-xl);
+  padding: 1.2rem 1.4rem 1.4rem;
+  animation: settingsMenuIn 0.18s ease-out;
+}
+
+.settings-menu[hidden] {
+  display: none;
+}
+
+.settings-menu .section-title {
+  display: block;
+  margin-bottom: 0.9rem;
+}
+
+@keyframes settingsMenuIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 #app {
@@ -170,7 +259,6 @@ h1, h2, h3 {
 /* === HERO === */
 .hero {
   padding: 1rem 5vw 1rem;
-  padding-top: calc(0.75rem + var(--safe-top));
   padding-left: calc(5vw + var(--safe-left));
   padding-right: calc(5vw + var(--safe-right));
   background: var(--bg-pure);
@@ -192,19 +280,6 @@ h1, h2, h3 {
   max-width: 1100px;
   margin: 0 auto;
   text-align: center;
-}
-
-.hero__eyebrow {
-  font-family: 'Bebas Neue', sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 0.3em;
-  color: #9aa7d6;
-  margin: 0 0 0.25rem;
-  font-size: 0.8rem;
-}
-
-.hero__eyebrow-category {
-  color: var(--turquoise-dark);
 }
 
 .hero__brand {
@@ -619,6 +694,36 @@ main {
   color: var(--bg-pure);
 }
 
+.badge--rank {
+  background: var(--turquoise-dark);
+  color: var(--bg-pure);
+}
+
+.badge--shared {
+  background: var(--turquoise-soft);
+  color: #0f766e;
+  border: 1px solid rgba(45, 212, 191, 0.45);
+}
+
+/* === TOP PICK CARDS === */
+.card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.card__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.9rem;
+}
+
+.card__actions .button {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+}
+
 /* === VISUALIZATION === */
 .visualization__controls {
   display: flex;
@@ -719,6 +824,39 @@ main {
   position: relative;
 }
 
+/* Pass a share link points at — steady emphasis instead of the pulse */
+.pass--shared {
+  border: 1.5px solid var(--turquoise-dark);
+  box-shadow: 0 0 0 3px var(--turquoise-soft);
+  animation: fadeIn 0.4s ease-out;
+}
+
+/* Brief attention flash when jumping to a pass (shared link / "View pass") */
+.pass--flash {
+  animation: passFlash 1.8s ease-out;
+}
+
+.pass--shared.pass--flash {
+  animation: passFlash 1.8s ease-out, fadeIn 0.4s ease-out;
+}
+
+@keyframes passFlash {
+  0%, 45% {
+    outline: 3px solid rgba(45, 212, 191, 0.75);
+    outline-offset: 3px;
+  }
+  100% {
+    outline: 3px solid transparent;
+    outline-offset: 3px;
+  }
+}
+
+.pass__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
 .pass__header {
   grid-column: 1 / -1;
   display: flex;
@@ -748,73 +886,90 @@ main {
   color: var(--text);
 }
 
-/* === SETTINGS DROPDOWN === */
-.settings-dropdown {
-  padding: 0;
-  overflow: hidden;
-}
-
-.settings-dropdown__toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 1rem 1.6rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
-  color: var(--text);
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-}
-
-.settings-dropdown__toggle:hover {
-  background: var(--accent-soft);
-}
-
-.settings-dropdown__chevron {
-  color: var(--muted);
-  transition: transform 0.25s ease;
-  flex-shrink: 0;
-}
-
-.settings-dropdown__toggle[aria-expanded="true"] .settings-dropdown__chevron {
-  transform: rotate(180deg);
-}
-
-.settings-dropdown__content {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 0.25s ease;
-}
-
-.settings-dropdown__content[hidden] {
-  display: none;
-}
-
-.settings-dropdown__content > .settings__grid {
-  overflow: hidden;
-  min-height: 0;
-}
-
-.settings-dropdown__toggle[aria-expanded="true"] + .settings-dropdown__content {
-  grid-template-rows: 1fr;
-}
-
-/* Fallback for mobile browsers without grid-template-rows transition support */
-.settings-dropdown.is-open .settings-dropdown__content {
-  grid-template-rows: 1fr;
-}
-
-.settings-dropdown__content .settings__grid {
-  padding: 0 1.6rem 1.4rem;
-}
-
+/* === SETTINGS GRID (inside topbar popover) === */
 .settings__grid {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+/* === SHARE BANNER === */
+.share-banner[hidden] {
+  display: none;
+}
+
+.share-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.7rem 0.9rem;
+  margin-bottom: 1rem;
+  background: var(--turquoise-soft);
+  border: 1px solid rgba(45, 212, 191, 0.35);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.share-banner__icon {
+  flex-shrink: 0;
+  color: var(--turquoise-dark);
+  margin-top: 3px;
+}
+
+.share-banner__text {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.share-banner__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  margin: -4px -4px 0 0;
+  transition: background 0.2s ease, color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.share-banner__dismiss:hover {
+  background: rgba(45, 212, 191, 0.18);
+  color: var(--text);
+}
+
+/* === TOAST === */
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(1.25rem + var(--safe-bottom));
+  transform: translate(-50%, 12px);
+  background: var(--text);
+  color: var(--bg-pure);
+  font-size: 0.88rem;
+  font-weight: 500;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 1300;
+  max-width: min(92vw, 480px);
+  text-align: center;
+}
+
+.toast--visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 /* === VASEY/AI Universal Footer === */
@@ -1108,9 +1263,18 @@ main {
 
 /* === RESPONSIVE - Mobile First === */
 @media (max-width: 900px) {
+  .topbar {
+    padding-left: calc(4vw + var(--safe-left));
+    padding-right: calc(4vw + var(--safe-right));
+  }
+
+  .settings-menu {
+    right: calc(4vw + var(--safe-right));
+    width: min(460px, calc(100vw - 8vw - var(--safe-left) - var(--safe-right)));
+  }
+
   .hero {
     padding: 0.75rem 4vw 0.75rem;
-    padding-top: calc(0.5rem + var(--safe-top));
     padding-left: calc(4vw + var(--safe-left));
     padding-right: calc(4vw + var(--safe-right));
   }
@@ -1153,10 +1317,6 @@ main {
 
   .hero h1 {
     font-size: 2.1rem;
-  }
-
-  .hero__eyebrow {
-    font-size: 0.75rem;
   }
 
   .hero__subhead {
@@ -1222,12 +1382,8 @@ main {
     grid-template-columns: 1fr 1fr;
   }
 
-  .settings-dropdown__toggle {
-    padding: 0.8rem 1.2rem;
-  }
-
-  .settings-dropdown__content .settings__grid {
-    padding: 0 1.2rem 1.2rem;
+  .settings-menu {
+    padding: 1.1rem 1.2rem 1.2rem;
   }
 
   .map, .globe {
@@ -1247,8 +1403,17 @@ main {
     padding: 0.6rem 0.8rem;
   }
 
-  .footer {
-    font-size: 0.78rem;
+  /* Keep card and pass actions compact and side-by-side on phones */
+  .card__actions .button,
+  .pass__actions .button {
+    width: auto;
+    flex: 1 1 auto;
+    font-size: 0.85rem;
+    padding: 0.6rem 0.8rem;
+  }
+
+  .pass__actions {
+    width: 100%;
   }
 }
 
@@ -1280,13 +1445,6 @@ main {
 
   .map, .globe {
     height: 260px;
-  }
-}
-
-/* PWA standalone mode adjustments */
-@media (display-mode: standalone) {
-  .hero {
-    padding-top: calc(1.25rem + var(--safe-top));
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -131,6 +131,9 @@ body {
 }
 
 .topbar__inner {
+  /* Containing block for the .settings-menu popover so it anchors to the
+     centered inner row (and its settings button), not the full-width bar */
+  position: relative;
   max-width: 1100px;
   margin: 0 auto;
   display: flex;
@@ -193,12 +196,12 @@ body {
   transform: rotate(45deg);
 }
 
-/* Settings popover anchored under the bar */
+/* Settings popover anchored under the bar, flush with the toggle's edge */
 .settings-menu {
   position: absolute;
   top: calc(100% + 10px);
-  right: calc(5vw + var(--safe-right));
-  width: min(460px, calc(100vw - 10vw - var(--safe-left) - var(--safe-right)));
+  right: 0;
+  width: min(460px, 100%);
   background: var(--panel);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
@@ -1266,11 +1269,6 @@ main {
   .topbar {
     padding-left: calc(4vw + var(--safe-left));
     padding-right: calc(4vw + var(--safe-right));
-  }
-
-  .settings-menu {
-    right: calc(4vw + var(--safe-right));
-    width: min(460px, calc(100vw - 8vw - var(--safe-left) - var(--safe-right)));
   }
 
   .hero {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -8,6 +8,17 @@ Accumulated patterns from corrections and mistakes. Review at session start.
 - **Why**: Stacking body padding + container padding + footer padding creates excessive whitespace on all devices, not just notched ones.
 - **Refinement (PR #35)**: "Outermost element" must not be a shared container when its children paint distinct full-width backgrounds. Horizontal insets on `#app` inset the hero's white surface away from the screen edge in landscape, exposing the gray body background beside it. Fold the inset into each section's own padding instead (`calc(5vw + var(--safe-left))` on `.hero`/`main`, plain inset on `.app-footer`) so backgrounds bleed edge-to-edge while content clears the notch. Still applied once per edge per element — never stacked.
 
+## URL Params vs Saved State Precedence
+
+- **Pattern**: When a feature writes URL parameters (share links, deep links), every parameter written must be consumed on load, and explicit URL state must take precedence over persisted local state (localStorage). Add a regression test for the parse path.
+- **Why**: The original share link wrote a `pass` param nothing ever read, and `init()` loaded the saved location *after* URL hydration — so share links silently showed the recipient's own saved location. The half of the feature that writes state is easy to demo; the half that consumes it is the part that breaks silently.
+- **Corollary**: Leaving shared mode (user picks their own location) should clean the share params via `history.replaceState` so a refresh doesn't resurrect stale context.
+
+## Sticky Positioning Inside Overflow Containers
+
+- **Pattern**: `position: sticky` fails silently inside any ancestor with `overflow` other than `visible` (e.g. `#app { overflow-x: hidden }`). Put sticky bars outside such containers (body level).
+- **Why**: The ancestor becomes the scrollport for stickiness; since it doesn't scroll vertically itself, the element never sticks.
+
 ## Version Synchronization
 
 - **Pattern**: When bumping the version, update all locations in a single commit: `package.json`, `index.html` version pill, `sw.js` cache name, `README.md` badge, and `CHANGELOG.md`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,19 @@
 # Task Plan
 
-## Current Session — 2026-06-11
+## Current Session — 2026-07-10
+
+- [x] Fix broken share links: consume `pass` param, stop saved location from overriding URL coords, match shared pass with ±15 min TLE-drift tolerance
+- [x] Pin + highlight + scroll to the shared pass; dismissible banner explains matched / already-occurred / unmatched outcomes
+- [x] Extract pure share helpers to `src/lib/share.js` with regression tests in `tests/share.test.js`
+- [x] Add rank badge + View pass / Share actions to Top Picks cards
+- [x] Move settings from in-flow collapsible panel to sticky top bar popover (mobile fix)
+- [x] Replace safe-area scrim with topbar-owned top inset; remove standalone hero override
+- [x] Add toast feedback for share/copy/reminder actions
+- [x] Compact side-by-side action buttons on mobile
+- [x] Bump 1.4.0 everywhere; update CHANGELOG, README, MANIFEST, lessons
+- [x] Verify: lint, unit tests, build, browser smoke test (share link, settings popover, mobile layout)
+
+## Previous Session — 2026-06-11
 
 - [x] Verify CLAUDE.md matches the canonical engineering standards (no drift found)
 - [x] Run full verification suite: npm ci, lint, tests, build — all green

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildShareParams,
+  parseShareParams,
+  findSharedPass,
+  isPlaceholderName,
+  PASS_MATCH_TOLERANCE_MS
+} from '../src/lib/share.js';
+
+const observer = { lat: 47.6062, lon: -122.3321 };
+
+const makePass = (startIso, durationMinutes = 10) => {
+  const start = new Date(startIso);
+  return {
+    start,
+    end: new Date(start.getTime() + durationMinutes * 60000)
+  };
+};
+
+describe('share link params', () => {
+  it('round-trips observer, pass time, and location name', () => {
+    const pass = makePass('2026-07-11T04:32:00.000Z');
+    const params = buildShareParams(observer, pass, 'Seattle, WA');
+    const parsed = parseShareParams(`?${params.toString()}`);
+    assert.equal(parsed.observer.lat, 47.6062);
+    assert.equal(parsed.observer.lon, -122.3321);
+    assert.equal(parsed.passTime.toISOString(), '2026-07-11T04:32:00.000Z');
+    assert.equal(parsed.locationName, 'Seattle, WA');
+  });
+
+  it('omits placeholder location names from links', () => {
+    const pass = makePass('2026-07-11T04:32:00.000Z');
+    for (const placeholder of ['Custom location', 'Locating...', 'Shared location']) {
+      const params = buildShareParams(observer, pass, placeholder);
+      assert.equal(params.has('loc'), false, `should omit "${placeholder}"`);
+      assert.ok(isPlaceholderName(placeholder));
+    }
+  });
+
+  it('clamps very long location names', () => {
+    const pass = makePass('2026-07-11T04:32:00.000Z');
+    const params = buildShareParams(observer, pass, 'x'.repeat(500));
+    assert.equal(params.get('loc').length, 80);
+    const parsed = parseShareParams(`?loc=${'y'.repeat(500)}&lat=10&lon=10`);
+    assert.equal(parsed.locationName.length, 80);
+  });
+
+  it('rejects out-of-range or malformed coordinates', () => {
+    assert.equal(parseShareParams('?lat=91&lon=0').observer, null);
+    assert.equal(parseShareParams('?lat=0&lon=-181').observer, null);
+    assert.equal(parseShareParams('?lat=abc&lon=10').observer, null);
+    assert.equal(parseShareParams('?lon=10').observer, null);
+    assert.equal(parseShareParams('').observer, null);
+  });
+
+  it('rejects malformed pass timestamps but keeps valid coordinates', () => {
+    const parsed = parseShareParams('?lat=47.6&lon=-122.3&pass=not-a-date');
+    assert.deepEqual(parsed.observer, { lat: 47.6, lon: -122.3 });
+    assert.equal(parsed.passTime, null);
+  });
+});
+
+describe('findSharedPass', () => {
+  const passes = [
+    makePass('2026-07-11T04:32:00.000Z'),
+    makePass('2026-07-11T06:08:00.000Z'),
+    makePass('2026-07-11T07:45:00.000Z')
+  ];
+
+  it('matches an exact start time', () => {
+    const match = findSharedPass(passes, new Date('2026-07-11T06:08:00.000Z'));
+    assert.equal(match, passes[1]);
+  });
+
+  it('matches within the drift tolerance', () => {
+    const target = new Date(passes[1].start.getTime() - PASS_MATCH_TOLERANCE_MS + 1000);
+    assert.equal(findSharedPass(passes, target), passes[1]);
+  });
+
+  it('matches a time inside the pass window', () => {
+    const target = new Date(passes[0].start.getTime() + 5 * 60000);
+    assert.equal(findSharedPass(passes, target), passes[0]);
+  });
+
+  it('prefers the pass whose start is nearest the target', () => {
+    // Midway-ish between pass 0 end and pass 1 start, closer to pass 1 start
+    const target = new Date('2026-07-11T05:58:00.000Z');
+    assert.equal(findSharedPass(passes, target), passes[1]);
+  });
+
+  it('returns null when nothing is near the target', () => {
+    assert.equal(findSharedPass(passes, new Date('2026-07-12T00:00:00.000Z')), null);
+    assert.equal(findSharedPass([], new Date('2026-07-11T04:32:00.000Z')), null);
+  });
+
+  it('returns null for missing or invalid targets', () => {
+    assert.equal(findSharedPass(passes, null), null);
+    assert.equal(findSharedPass(passes, new Date('garbage')), null);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two reported issues — broken top-pick/share links and the awkward mobile settings panel — plus the design/UX polish around them. All existing features retained. Bumps to **v1.4.0**.

### 🔗 Share links actually work now

Two root causes made shared pass links dead on arrival:

1. `buildShareUrl()` wrote a `pass` param that **nothing ever read** (true since the feature's first commit).
2. `init()` loaded the saved localStorage location **after** URL hydration, so on any device that had used the app before, the shared coordinates were silently overwritten by the recipient's own saved location.

Now:
- Share params are parsed by a new pure module `src/lib/share.js` (`buildShareParams` / `parseShareParams` / `findSharedPass`) with regression tests.
- URL coords take precedence over the saved location; the link's `loc` name shows immediately (background reverse geocode when absent).
- The shared pass is matched against freshly computed passes with **±15 min tolerance** (absorbs TLE drift between sharer and recipient; adjacent passes are ~90 min apart so no ambiguity), pinned into the display list regardless of pagination, badged **"Shared pick"**, highlighted, and scrolled into view.
- A dismissible banner explains the outcome — including friendly messaging when the shared pass already occurred or no longer matches orbital data.
- Manually changing location exits shared mode and cleans the URL (`history.replaceState`) so refresh behaves normally.

**Try it on the Vercel preview:** open the preview URL, hit Share on a Top Pick or pass card, then open the copied link in a private window (or after setting a different location) — the shared location and highlighted pass load correctly.

### ⭐ Top Picks get real actions

Each pick card now has a rank badge (Pick 1/2/3) and two actions: **View pass** (jumps to the full card in Upcoming Passes, navigating pagination, with a flash highlight) and **Share** (native share sheet, clipboard fallback + toast).

### ⚙️ Settings moved to a sticky top bar

The full-width collapsible SETTINGS panel wedged mid-page (the "goofy" mobile look) is gone. A slim, always-visible top bar now carries the VASEY/SPACE brand (moved from the hero eyebrow — no duplication) and a **Settings** gear button opening an anchored popover: same four controls, same persistence, reachable from anywhere. Disclosure semantics (`aria-expanded`/`aria-controls`), Escape-to-close with focus return, outside-tap close.

The sticky bar also **owns the top safe-area inset** (applied once, per `tasks/lessons.md`), replacing the fixed `body::before` scrim — content scrolls under a blurred translucent surface, iOS status-bar region included. Note: the bar lives outside `#app` because `overflow-x: hidden` there would silently disable `position: sticky`.

### 🎨 Polish

- Toast notifications (`role="status"`, `aria-live="polite"`) for share/copy/reminder feedback — copy feedback previously appeared as text inside the distant Location panel.
- Share/Reminder and card actions render compact + side-by-side on phones instead of stacked full-width.
- Top picks/passes no longer show already-ended passes when re-rendered hours later.
- Fixed a latent bug found during verification: `.share-banner { display: flex }` would have overridden the UA `[hidden]` rule (guarded with `[hidden] { display: none }`).

## Verification

- `npm run lint` — 10 files clean
- `npm test` — **14/14** (3 existing + 11 new share-helper regression tests)
- `npm run build` — clean; `npm audit` — 0 vulnerabilities
- **31/31 Playwright end-to-end checks** against the production build, including the exact regression scenario: share link opened on a device with a *different saved location* → shared location wins, pass matched (17 s drift), highlighted, scrolled into view; past-pass messaging; URL cleanup on manual change; settings popover open/Escape/outside-click/persist; sticky topbar when scrolled; 390 px mobile layout; clipboard share + toast.
- Screenshots reviewed on mobile (390×844) and desktop (1366×900) viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mb2SSgHUY6KY8SV7ZdK7TA